### PR TITLE
Removing the `waitForResponse` Parameter from WebSocket Commands

### DIFF
--- a/cmd/decache.go
+++ b/cmd/decache.go
@@ -31,8 +31,8 @@ func init() {
 // the "decache" command to the server.
 // It is set to send the command without waiting for a response from the server.
 func runDecacheCmd(cmd *cobra.Command, args []string) {
-	waitForResponse := false
-	err := shared.ExecuteWebSocketCommand("decache", "", waitForResponse)
+	queryMessage := ""
+	err := shared.ExecuteWebSocketCommand("decache", queryMessage)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/cmd/o.go
+++ b/cmd/o.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/neh-cli/neh/cmd/shared"
@@ -27,9 +28,12 @@ func runOCmd(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	originalMessage := strings.Join(args, " ")
-	waitForResponse := false
-	err := shared.ExecuteWebSocketCommand("o", originalMessage, waitForResponse)
+	queryMessage := strings.Join(args, " ")
+	if os.Getenv("NEH_DEBUG") == "t" {
+		fmt.Printf("Query Message: %s\n", queryMessage)
+	}
+
+	err := shared.ExecuteWebSocketCommand("o", queryMessage)
 
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/shared/utils.go
+++ b/cmd/shared/utils.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 )
 
-func ExecuteWebSocketCommand(command, message string, waitForResponse bool) error {
+func ExecuteWebSocketCommand(command, message string) error {
 	personalAccessToken, err := getPersonalAccessToken()
 	if err != nil {
 		return err
@@ -32,7 +32,8 @@ func ExecuteWebSocketCommand(command, message string, waitForResponse bool) erro
 	}
 	defer conn.Close(websocket.StatusInternalError, "Internal error")
 
-	handleWebSocketMessages(ctx, conn, command, message, &sync.Map{}, waitForResponse)
+	requestSent := false
+	handleWebSocketMessages(ctx, conn, command, message, &sync.Map{}, requestSent)
 	return nil
 }
 
@@ -143,6 +144,7 @@ func handleWelcomeMessage(conn *websocket.Conn) {
 }
 
 func handleConfirmSubscriptionMessage(conn *websocket.Conn, message map[string]interface{}, command, originalMessage string, requestSent *bool) {
+	// Ensure the subscription request is not sent more than once
 	if *requestSent {
 		return
 	}

--- a/cmd/shared/utils_test.go
+++ b/cmd/shared/utils_test.go
@@ -13,7 +13,7 @@ import (
 func TestExecuteWebSocketCommand(t *testing.T) {
 	os.Setenv("NEH_PERSONAL_ACCESS_TOKEN", "dummy_token")
 
-	err := ExecuteWebSocketCommand("test_command", "test_message", false)
+	err := ExecuteWebSocketCommand("test_command", "test_message")
 	if err != nil {
 		t.Errorf("ExecuteWebSocketCommand failed: %v", err)
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Define the version information
-const Version = "0.0.10"
+const Version = "0.0.11"
 
 // versionCmd represents the `neh version` command
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
Remove the waitForResponse Parameter from WebSocket Commands.

This commit refactors the WebSocket command execution by removing the `waitForResponse` parameter from the `ExecuteWebSocketCommand` function.

The parameter has been replaced with an internal mechanism to ensure requests are not sent more than once. This change simplifies the function signature and improves code clarity.

Additionally, the environment variable `NEH_DEBUG` has been integrated for debugging purposes to print query messages. The version has been incremented from 0.0.10 to 0.0.11 to reflect these updates.