### PR TITLE
Update Environment Variable Check and Bump Version to 0.0.15

### DIFF
--- a/cmd/shared/utils.go
+++ b/cmd/shared/utils.go
@@ -277,7 +277,7 @@ func handleHttpResponse(resp *http.Response) error {
 }
 
 func getNehServerEndpoint(command string) string {
-	if os.Getenv("WORKING_ON_LOCALHOST") == "t" {
+	if os.Getenv("WORKING_ON_LOCALHOST") != "" {
 		developmentEndpoint := os.Getenv("NEH_SERVER_ENDPOINT_DEVELOPMENT")
 		if developmentEndpoint == "" {
 			panic("The environment variable NEH_SERVER_ENDPOINT_DEVELOPMENT is not set")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Define the version information
-const Version = "0.0.14"
+const Version = "0.0.15"
 
 // versionCmd represents the `neh version` command
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
- Modified the check for the WORKING_ON_LOCALHOST environment variable to ensure it is not empty instead of checking for a specific value.
- Incremented the application version from 0.0.14 to 0.0.15 in version.go.