### PR TITLE
feat: Add Configuration Command for Language Settings

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,110 @@
+// File: cmd/config.go
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Lang string `yaml:"lang"`
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage configuration settings",
+}
+
+var langCmd = &cobra.Command{
+	Use:   "lang [ja|en|...]",
+	Short: "Set language (e.g. en, ja, zh, es, fr, de)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		lang := args[0]
+		configPath := getConfigPath()
+
+		cfg := Config{Lang: lang}
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			fmt.Println("Failed to create config directory:", err)
+			return
+		}
+
+		f, err := os.Create(configPath)
+		if err != nil {
+			fmt.Println("Failed to create config file:", err)
+			return
+		}
+		defer f.Close()
+
+		encoder := yaml.NewEncoder(f)
+		defer encoder.Close()
+		if err := encoder.Encode(&cfg); err != nil {
+			fmt.Println("Failed to write config:", err)
+		} else {
+			fmt.Printf("Language set to '%s' in %s\n", lang, configPath)
+		}
+	},
+}
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Display current configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		configPath := getConfigPath()
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			fmt.Printf("Failed to read config file: %v\n", err)
+			return
+		}
+
+		var cfg Config
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			fmt.Printf("Failed to parse config file: %v\n", err)
+			return
+		}
+
+		fmt.Println("Current configuration:")
+		fmt.Printf("lang: %s\n", cfg.Lang)
+	},
+}
+
+var resetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Delete all configuration (with confirmation)",
+	Run: func(cmd *cobra.Command, args []string) {
+		configDir := filepath.Dir(getConfigPath())
+
+		fmt.Printf("Are you sure you want to delete %s? (y/N): ", configDir)
+		var response string
+		fmt.Scanln(&response)
+
+		if response != "y" && response != "Y" {
+			fmt.Println("Aborted. Configuration not deleted.")
+			return
+		}
+
+		if err := os.RemoveAll(configDir); err != nil {
+			fmt.Printf("Failed to delete config directory: %v\n", err)
+			return
+		}
+		fmt.Println("Configuration reset: directory deleted.")
+	},
+}
+
+func getConfigPath() string {
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, ".config", "neh", "config.yml")
+}
+
+func init() {
+	configCmd.AddCommand(langCmd)
+	configCmd.AddCommand(showCmd)
+	configCmd.AddCommand(resetCmd)
+	rootCmd.AddCommand(configCmd)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Define the version information
-const Version = "0.0.15"
+const Version = "0.0.16"
 
 // versionCmd represents the `neh version` command
 var versionCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,4 +13,5 @@ github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3k
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- Implemented config command to manage language settings
- Added support for setting languages such as en, ja, zh, es, fr, de
- Integrated YAML v3 package for configuration management