### PR TITLE
Add Language Support to Request Body

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Define the version information
-const Version = "0.0.16"
+const Version = "0.0.17"
 
 // versionCmd represents the `neh version` command
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
- Implemented language retrieval from config.yml to include in the request body.
- Default language set to 'en' if config file is unavailable or language setting is unspecified.
- Added debug output for language setting when NEH_DEBUG environment variable is set.